### PR TITLE
add choice to keep existing filesystem size

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+This is a modification of the original rpi-clone by Bill Wilson. 
 
 rpi-clone is a shell script that will back up (clone using dd and rsync)
 a running Raspberry Pi file system to a destination SD card 'sdN' plugged
@@ -29,7 +30,7 @@ This is done by a partial 'dd' from the running booted device /dev/mmcblk0
 to the destination SD card /dev/sdN followed by a fdisk resize and mkfs.ext4
 of /dev/sdN partition 2.  This creates a completed partition 1 containing
 all boot files and an empty but properly sized partition 2 rootfs.
-The SD card  partitions are then mounted on /mnt/clone and rsynced to the
+The SD card partitions are then mounted on /mnt/clone and rsynced to the
 running system.
 
 You should avoid running other disk writing programs when running rpi-clone,
@@ -76,6 +77,16 @@ or, use git to clone the repository:
 	$ cd rpi-clone
 	$ cp rpi-clone /usr/local/sbin
 
-
 Bill Wilson
 billw--at--gkrellm.net
+
+Updated March 2014 by William Phelps - ask if file system should be
+expanded to fill destination SD card or not.
+
+A larger SD card will greatly improve wear levelling, thus increasing the
+life of the card. However, the file system does not need to be expanded
+to take advantage of this. Larger file systems make for larger backup images.
+I wanted a version of this tool that would preserve the exisiting file
+system size.
+
+https://github.com/wbphelps/rpi-clone-wm.git

--- a/rpi-clone
+++ b/rpi-clone
@@ -181,6 +181,16 @@ expand_rootfs()
 	# Get the starting offset of the root partition
 	PART_START=$(parted /dev/mmcblk0 -ms unit s p | grep "^2" | cut -f 2 -d:)
 	[ "$PART_START" ] || return 1
+	echo -n "Do you want to expand the destination /dev/$DST_DISK? (yes/no): "
+	read resp
+	if [ "$resp" = "y" ] || [ "$resp" = "yes" ]
+	then
+		PART_END=""
+	else
+		# Get the end offset of the root partition
+		PART_END=$(parted /dev/mmcblk0 -ms unit s p | grep "^2" | cut -f 3 -d:)
+		[ "$PART_END" ] || return 1
+	fi
 	# Return value will likely be error for fdisk as it fails to reload the
 	# partition table because the root fs is mounted
 	fdisk /dev/$DST_DISK > /dev/null <<EOF
@@ -191,7 +201,7 @@ n
 p
 2
 $PART_START
-
+$PART_END
 p
 w
 q
@@ -256,9 +266,9 @@ then
 		# maybe the wrong size for the destination SD card.  So fdisk it to
 		# make it fill the rest of the disk and mkfs it to clean it out.
 		#
-		echo "Sizing partition 2 (root partition) to use all SD card space..."
 		expand_rootfs
-		mkfs.ext4 $DST_ROOT_PARTITION > /dev/null
+#		mkfs.ext4 $DST_ROOT_PARTITION > /dev/null
+		mkfs.ext4 $DST_ROOT_PARTITION
 
 		echo ""
 		echo "/dev/$DST_DISK is initialized and resized.  Its partitions are:"


### PR DESCRIPTION
A small change to rpi-clone to keep the existing file system sizes rather than expanding to fill the target SD card.
