### PR TITLE
quite modus to enable cron use

### DIFF
--- a/rpi-clone
+++ b/rpi-clone
@@ -1,6 +1,13 @@
 #!/bin/bash
 
-VERSION=1.2
+VERSION=1.3
+# Version 1.3	2015/06/18
+#	* add -q (quiet) option for use as cron script
+#         -q only works with existing backups, 
+#         it won't initialize the destination SD card partitions with dd!
+#         Please initialize the destination SD card from the shell (by hand)
+#         for the first time.
+#         This is to protect you for accidentally overwriting a SD Card.
 # Version 1.2	2015/02/17
 #	* add -x option
 #	* tweak some echo messages
@@ -59,11 +66,12 @@ fi
 usage()
 	{
 	echo ""
-	echo "usage: $PGM sdN {-f|--force-initialize} {-v|--verbose} {-x}"
+	echo "usage: $PGM sdN {-f|--force-initialize} {-v|--verbose} {-x} {-q|--quite}"
 	echo "    Example:  $PGM sda"
 	echo "    -v - list all files as they are copied."
 	echo "    -f - force initialize the destination partitions"
 	echo "    -x - use set -x for very verbose bash shell script debugging"
+	echo "    -q - use quiet modus to schedule the script as a cron script"
 	echo ""
 	echo "    Clone (rsync) a running Raspberry Pi file system to a destination"
 	echo "    SD card 'sdN' plugged into a Pi USB port (via a USB card reader)."
@@ -96,6 +104,7 @@ usage()
 	}
 
 VERBOSE=off
+QUITE_FOR_CRON=false
 
 while [ "$1" ]
 do
@@ -112,6 +121,9 @@ do
 			;;
 		-h|--help)
 			usage
+			;;
+		-q|--quite)
+			QUITE_FOR_CRON=true
 			;;
 		*)
 			if [ "$DST_DISK" != "" ]
@@ -143,6 +155,12 @@ fi
 
 unmount_or_abort()
 	{
+	if [ "$QUITE_FOR_CRON" = "true" ]
+	then
+		echo "Sorry, mounted devices in quite_cron mode is not allowed."
+		echo -e "Aborting!\n"
+		exit 0
+	fi
 	echo -n "Do you want to unmount $1? (yes/no): "
 	read resp
 	if [ "$resp" = "y" ] || [ "$resp" = "yes" ]
@@ -246,6 +264,12 @@ if [ "$DST_BOOT_PARTITION_TYPE" != "$SRC_BOOT_PARTITION_TYPE" ] || \
    [ "$DST_ROOT_PARTITION_TYPE" != "$SRC_ROOT_PARTITION_TYPE" ] || \
    [ "$FORCE_INITIALIZE" = "true" ]
 then
+	if [ "$QUITE_FOR_CRON" = "true" ]
+	then
+		echo "Sorry, now new disk setup allowed in quite_cron mode."
+		echo -e "Aborting!\n"
+		exit 0
+	fi
 	CLONE_MODE="rsync all files to $DST_DISK root file system"
 	echo ""
 	if [ "$FORCE_INITIALIZE" = "true" ]
@@ -352,8 +376,14 @@ echo "==============================="
 # If this is an SD card initialization, can watch progress of the clone
 # in another terminal with:  watch df -h
 #
-echo -n "Final check, is it Ok to proceed with the clone (yes/no)?: "
-read resp
+
+if [ "$QUITE_FOR_CRON" != "true" ]
+then
+	echo -n "Final check, is it Ok to proceed with the clone (yes/no)?: "
+	read resp
+else
+	resp="y"
+fi
 if [ "$resp" != "y" ] && [ "$resp" != "yes" ]
 then
 	echo -e "Aborting the disk clone.\n"
@@ -476,9 +506,11 @@ echo ""
 # Eg. modify $CLONE/etc/hostname, $CLONE/etc/network/interfaces, etc
 # if I'm cloning into a card to be installed on another Pi.
 #
-echo -n "Hit Enter when ready to unmount the /dev/$DST_DISK partitions..."
-read resp
-
+if [ "$QUITE_FOR_CRON" != "true" ]
+then
+	echo -n "Hit Enter when ready to unmount the /dev/$DST_DISK partitions..."
+	read resp
+fi
 echo "unmounting $CLONE/boot"
 umount $CLONE/boot
 


### PR DESCRIPTION
# Version 1.3   2015/06/18

add -q (quiet) option for use as cron script

-q only works with existing backups. It won't initialize the destination SD card partitions with dd! Please initialize the destination SD card from the shell (by hand) for the first time. This is to protect you for accidentally overwriting a SD Card.

I use this script since March 2015 for backing up my raspberry pi via cron job.

Thank you for your great work! 
