### PR TITLE
add trusted paths that often fail if run via cron

### DIFF
--- a/rpi-clone
+++ b/rpi-clone
@@ -10,6 +10,9 @@
 
 version=2.0.22
 
+# setup trusted paths for dependancies (like rsync, grub, fdisk, etc)
+export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+
 # auto run grub-install if grub detected
 grub_auto=1
 


### PR DESCRIPTION
Seen issues/reports of failures via cron because dependent scripts are not in the proper path. 