### PR TITLE
Keep filesystem labels

### DIFF
--- a/rpi-clone
+++ b/rpi-clone
@@ -546,26 +546,80 @@ print_options()
 	printf "%-23s:\n" "-----------------------"
 	}
 
-ext_label()
+dst_part_label()
 	{
 	pnum=$1
 	fs_type=$2
-	flag=$3
-	label_arg=""
+	label=""
 
 	if [ "$ext_label" != "" ] && [[ "$fs_type" == *"ext"* ]]
 	then
 		rep="${ext_label: -1}"
 		if [ "$rep" == "#" ]
 		then
-			label_arg=${ext_label:: -1}
-			label_arg="$flag $label_arg$pnum"
+			label="${ext_label:: -1}"
 		elif ((pnum == root_part_num))
 		then
-			label_arg="$flag $ext_label"
+			label="$ext_label"
 		fi
 	fi
-	printf -v "${4}" "%s" "$label_arg"
+
+	if [ -z "$label" -a -n "${src_label[$pnum]}" ]
+	then
+		label="${src_label[$pnum]}"
+	fi
+	printf -v "${3}" "%s" "$label"
+	}
+
+mkfs_label()
+	{
+	pnum=$1
+	fs_type=$2
+
+	label_flag=""
+	case "$fs_type" in
+		# This list is probably overcomplete, but might simplify
+		# future additions.
+		vfat|msdos|exfat|fat16|fat32)
+			label_flag=-n
+			;;
+		ext2|ext3|ext4|ntfs|xfs)
+			label_flag=-L
+			;;
+		hfs|hfsplus)
+			label_flag=-v
+			;;
+		reiserfs)
+			label_flag=-l
+			;;
+	esac
+
+
+	label_arg=""
+	dst_part_label "$pnum" "$fs_type" label
+	if [ -n "$label" -a -n "$label_flag" ]
+	then
+		label_arg="$label_flag $label"
+	fi
+	printf -v "${3}" "%s" "$label_arg"
+	}
+
+change_label()
+	{
+	pnum=$1
+	fs_type=$2
+	dev=$3
+
+	dst_part_label "$pnum" "$fs_type" label
+	if [ "$label" != "" ] && [[ "$fs_type" == *"ext"* ]]
+	then
+		echo "     e2label $dev $label"
+		e2label $dev $label
+	elif [ "$label" != "" ] && [[ "$fs_type" == *"fat"* ]]
+	then
+		echo "     fatlabel $dev $label"
+		fatlabel $dev $label
+	fi
 	}
 
 get_src_disk()
@@ -1501,9 +1555,9 @@ Use -U for unattended even if initializing.
 
 		if [ "${src_mounted_dir[p]}" == "/boot" ] && ((p == 1))
 		then
-			ext_label $p "$fs_type" "-L" label
-			printf "  => mkfs -t $mkfs_type $label $dst_dev ..."
-			yes | mkfs -t $mkfs_type $label $dst_dev &>> /tmp/$PGM-output
+			mkfs_label $p "$fs_type" label_opt
+			printf "  => mkfs -t $fs_type $label_opt $dst_dev ..."
+			yes | mkfs -t $mkfs_type $label_opt $dst_dev &>> /tmp/$PGM-output
 			echo ""
 		else
 			if [ "$fs_type" == "swap" ]
@@ -1514,9 +1568,9 @@ Use -U for unattended even if initializing.
 			then
 				if [ "${src_mounted_dir[p]}" != "" ] || ((p == n_image_parts))
 				then
-					ext_label $p $fs_type "-L" label
-					printf "  => mkfs -t $mkfs_type $label $dst_dev ..."
-					yes | mkfs -t $mkfs_type $label $dst_dev &>> /tmp/$PGM-output
+					mkfs_label "$p" "$fs_type" label_opt
+					printf "  => mkfs -t $mkfs_type $label_opt $dst_dev ..."
+					yes | mkfs -t $mkfs_type $label_opt $dst_dev &>> /tmp/$PGM-output
 					echo ""
 					if ((p == n_image_parts))
 					then
@@ -1536,12 +1590,7 @@ Use -U for unattended even if initializing.
 					else
 						echo ""
 					fi
-					ext_label $p $fs_type "" label
-					if [ "$label" != "" ]
-					then
-						echo "     e2label $dst_dev $label"
-						e2label $dst_dev $label
-					fi
+					change_label "$p" "$fs_type" "$dst_dev"
 				fi
 			fi
 		fi
@@ -1663,13 +1712,7 @@ do
 		sync_msg_done=1
 		dst_dev=/dev/${dst_part_base}${p}
 		fs_type=${src_fs_type[$p]}
-		ext_label $p $fs_type "" label
-		if [ "$label" != "" ]
-		then
-			qecho "     e2label $dst_dev $label"
-			e2label $dst_dev $label
-		fi
-
+		change_label "$p" "$fs_type" "$dst_dev"
 		mount_partition ${src_device[p]} $clone_src ""
 		mount_partition $dst_dev $clone "$clone_src"
 		unmount_list="$clone_src $clone"
@@ -1681,12 +1724,7 @@ done
 qprintf "Syncing mounted partitions:\n"
 
 fs_type=${src_fs_type[$root_part_num]}
-ext_label $root_part_num $fs_type "" label
-if [ "$label" != "" ]
-then
-	qecho "     e2label $dst_root_dev $label"
-	e2label $dst_root_dev $label
-fi
+change_label "$root_part_num" "$fs_type" "$dst_root_dev"
 
 mount_partition $dst_root_dev $clone ""
 unmount_list="$clone"
@@ -1709,12 +1747,7 @@ do
 
 		dst_dev=/dev/${dst_part_base}${p}
 		fs_type=${src_fs_type[$p]}
-		ext_label $p $fs_type "" label
-		if [ "$label" != "" ]
-		then
-			qecho "     e2label $dst_dev $label"
-			e2label $dst_dev $label
-		fi
+		change_label "$p" "$fs_type" "$dst_dev"
 
 		mount_partition "$dst_dev" "$dst_dir" "$unmount_list"
 		rsync_file_system "${src_mounted_dir[p]}/" "${dst_dir}" ""

--- a/rpi-clone
+++ b/rpi-clone
@@ -1766,12 +1766,7 @@ fi
 
 rm -f $clone/etc/udev/rules.d/70-persistent-net.rules
 
-dst_root_vol_name=`e2label $dst_root_dev`
-
-if [ "$dst_root_vol_name" = "" ]
-then
-	dst_root_vol_name="no label"
-fi
+dst_root_vol_name=${dst_label[$root_part_num]}
 
 if ((have_grub))
 then

--- a/rpi-clone
+++ b/rpi-clone
@@ -692,6 +692,9 @@ fi
 #
 src_partition_table=$(parted --script -m "/dev/$src_disk" unit s print | tr -d ';')
 src_fdisk_table=$(fdisk -l /dev/$src_disk | grep "^/dev/")
+# Parted seems to force a partition rescan, which hides fs labels from
+# lsblk output. Wait for kernel/udev to be done processing.
+udevadm settle
 
 tmp=$(df | grep -e "^/dev/$src_disk" -e "^/dev/root" -e "$src_root_dev" \
 			| tr -s " ")
@@ -1138,6 +1141,10 @@ then
 fi
 
 dst_partition_table=$(parted --script -m "/dev/$dst_disk" unit s print | tr -d ';')
+# Parted seems to force a partition rescan, which hides fs labels from
+# lsblk output. Wait for kernel/udev to be done processing.
+udevadm settle
+
 n_dst_parts=$(echo "$dst_partition_table" | tail -n 1 | cut -d ":" -f 1)
 if [ "$n_dst_parts" == "/dev/$dst_disk" ]
 then

--- a/rpi-clone
+++ b/rpi-clone
@@ -690,7 +690,7 @@ fi
 # src_root_dev, if on device other than booted, is not in src_partition_table
 # and src_fdisk_table, but is in src_df_table and src_mount_table
 #
-src_partition_table=$(parted -m "/dev/$src_disk" unit s print | tr -d ';')
+src_partition_table=$(parted --script -m "/dev/$src_disk" unit s print | tr -d ';')
 src_fdisk_table=$(fdisk -l /dev/$src_disk | grep "^/dev/")
 
 tmp=$(df | grep -e "^/dev/$src_disk" -e "^/dev/root" -e "$src_root_dev" \
@@ -1137,7 +1137,7 @@ then
 	exit 1
 fi
 
-dst_partition_table=$(parted -m "/dev/$dst_disk" unit s print | tr -d ';')
+dst_partition_table=$(parted --script -m "/dev/$dst_disk" unit s print | tr -d ';')
 n_dst_parts=$(echo "$dst_partition_table" | tail -n 1 | cut -d ":" -f 1)
 if [ "$n_dst_parts" == "/dev/$dst_disk" ]
 then

--- a/rpi-clone
+++ b/rpi-clone
@@ -739,13 +739,10 @@ do
 		src_name[p]="${src_mounted_dir[p]}"
 	fi
 
-	if [[ "$part_type" == *"ext"* ]]
+	label=`lsblk --raw --output label --noheadings "${src_device[p]}"`
+	if [ "$label" != "" ]
 	then
-		label=`e2label ${src_device[p]} 2> /dev/null`
-		if [ "$label" != "" ]
-		then
-			src_label[p]="$label"
-		fi
+		src_label[p]="$label"
 	fi
 done
 
@@ -1139,16 +1136,15 @@ do
 	if [[ "$part_type" == *"linux-swap"* ]]
 	then
 		dst_fs_type[p]="swap"
-	elif [[ "$part_type" == *"ext"* ]]
+	elif ((p == ext_num))
 	then
-		label=`e2label ${dst_device[p]} 2> /dev/null`
+		dst_fs_type[p]="EXT"
+	else
+		label=`lsblk --raw --output label --noheadings "${dst_device[p]}"`
 		if [ "$label" != "" ]
 		then
 			dst_label[p]="$label"
 		fi
-	elif ((p == ext_num))
-	then
-		dst_fs_type[p]="EXT"
 	fi
 done
 


### PR DESCRIPTION
This makes some changes to display and preserve all filesystem labels rather than just for ext filesystems.

Displaying of labels should be supported for any filesystem supported by the kernel (using `lsblk`), while copying labels is supported for a limited set of filesystems (just ext and fat for existing filesystems, a few more for new filesystems).

See the commit messages for some more details.