### PR TITLE
Don't convert partuuids for empty src_partition element

### DIFF
--- a/rpi-clone
+++ b/rpi-clone
@@ -957,6 +957,10 @@ then
 	count=0
 	for ((p = 1; p <= n_src_parts; p++))
 	do
+		if ((!src_exists[p]))
+		then
+			continue
+		fi
 		if grep -q "^/dev/${src_partition[p]}" $fstab_tmp
 		then
 			partuuid=$(lsblk -n -o PARTUUID /dev/${src_partition[p]})


### PR DESCRIPTION
## Issue
When converting to partuuids, if there is an empty element in `${src_partition[@]}`, then `/etc/fstab` will have `/dev/` replaced with `PARTUUID=` without actually changing the device name to a PARTUUID.

I don't have the exact logs when this happened to me, but it looked something like this:
```console
$ sudo rpi-clone -l sda --convert-fstab-to-partuuid

This will change your /etc/fstab, are you sure?  (yes/no): yes

Converting /etc/fstab from device names to PARTUUID
lsblk: /dev/: not a block device
  Editing /etc/fstab, changing /dev/ to
...
```

and I ended up with a broken fstab:
```fstab
proc            /proc           proc    defaults          0       0
PARTUUID=mmcblk0p6  /boot           vfat    defaults          0       2
PARTUUID=mmcblk0p7  /               ext4    defaults,noatime  0       1
# a swapfile is not a swap partition, no line here
#   use  dphys-swapfile swap[on|off]  for that
```

I had previously run `sudo rpi-clone -l sda` so perhaps that is why there was an empty element in `src_partition`, I'm not sure.

## Changes
Check that `${src_partition[p]}` is not empty before editing `/etc/fstab`.

Then, the command I used will instead exit with an error, which is much safer:
```
Could not find any sda partition names in /etc/fstab, nothing changed.
```