### PR TITLE
Fix boot partition detection for modern Raspberry Pi OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,18 @@
-## rpi-clone
-Latest version: 2.0.22
+## rpi-clone - Actively Maintained Fork
+Latest version: 2.0.23
+
+> **🔧 This is an actively maintained fork** of the original rpi-clone by billw2. The original repository hasn't been updated since 2020, leaving critical compatibility issues unresolved. This fork includes essential fixes for modern Raspberry Pi OS and ongoing maintenance.
+
+### Key Improvements in This Fork:
+- ✅ **Fixed boot partition detection** for modern Raspberry Pi OS (Bookworm/2024+) that uses `/boot/firmware`
+- ✅ **Backward compatible** with older systems using `/boot`
+- ✅ **Actively maintained** with bug fixes and compatibility updates
+- ✅ **Responsive to issues** and pull requests
+
+### Why Use This Fork?
+The original rpi-clone fails on modern Raspberry Pi OS systems because the boot partition location changed from `/boot` to `/boot/firmware`. This results in cloned SD cards that won't boot. This fork fixes that critical issue and maintains compatibility with both old and new systems.
+
+---
 
 Version 2 is a complete rewrite with improved capability over
 the original.  See the examples below.
@@ -45,7 +58,7 @@ only Debian packages with apt-get.
 
 #### On a Raspberry Pi:
 ```
-	$ git clone https://github.com/billw2/rpi-clone.git 
+	$ git clone https://github.com/KenAdamson/rpi-clone.git 
 	$ cd rpi-clone
 	$ sudo cp rpi-clone rpi-clone-setup /usr/local/sbin
 ```
@@ -66,7 +79,7 @@ add them to the rpi-clone-setup script.
   To install on another OS, rpi-clone may be renamed to suit.  For example,
   on my Debian desktop I rename:
 ```
-	$ git clone https://github.com/billw2/rpi-clone.git 
+	$ git clone https://github.com/KenAdamson/rpi-clone.git 
 	$ cd rpi-clone
 	$ sudo cp rpi-clone /usr/local/sbin/sys-clone
 	$ sudo cp rpi-clone-setup /usr/local/sbin/sys-clone-setup

--- a/rpi-clone
+++ b/rpi-clone
@@ -586,7 +586,13 @@ get_src_disk()
 
 # ==== source (booted) disk info and default mount list
 #
-src_boot_dev=`findmnt /boot -o source -n | grep "/dev/"`
+# Check for boot partition at /boot/firmware (modern Raspberry Pi OS) first,
+# then fall back to /boot (legacy location) for backward compatibility
+src_boot_dev=`findmnt /boot/firmware -o source -n 2>/dev/null | grep "/dev/"`
+if [ "$src_boot_dev" == "" ]
+then
+	src_boot_dev=`findmnt /boot -o source -n 2>/dev/null | grep "/dev/"`
+fi
 src_root_dev=`findmnt / -o source -n | grep "/dev/"`
 SD_slot_boot=0
 SD_slot_dst=0
@@ -971,7 +977,13 @@ then
 		cp $fstab_tmp $fstab
 		printf "Your original fstab is backed up to $fstab_save\n"
 
-		cmdline_txt=/boot/cmdline.txt
+		# Check for cmdline.txt in both locations
+		if [ -f /boot/firmware/cmdline.txt ]
+		then
+			cmdline_txt=/boot/firmware/cmdline.txt
+		else
+			cmdline_txt=/boot/cmdline.txt
+		fi
 		cmdline_save=$cmdline_txt.${PGM}-save
 		if [ -f $cmdline_txt ] && grep -q "$src_root_dev" $cmdline_txt
 		then
@@ -1503,7 +1515,8 @@ Use -U for unattended even if initializing.
 			mkfs_type=$fs_type
 		fi
 
-		if [ "${src_mounted_dir[p]}" == "/boot" ] && ((p == 1))
+		# Check for both /boot and /boot/firmware mount points for compatibility
+		if ([ "${src_mounted_dir[p]}" == "/boot" ] || [ "${src_mounted_dir[p]}" == "/boot/firmware" ]) && ((p == 1))
 		then
 			ext_label $p "$fs_type" "-L" label
 			printf "  => mkfs -t $mkfs_type $label $dst_dev ..."
@@ -1730,15 +1743,28 @@ qecho ""
 # Fix PARTUUID or device name references in cmdline.txt and fstab
 #
 fstab=${clone}/etc/fstab
-cmdline_txt=${clone}/boot/cmdline.txt
+# Check for cmdline.txt in both /boot/firmware (modern) and /boot (legacy)
+if [ -f ${clone}/boot/firmware/cmdline.txt ]
+then
+	cmdline_txt=${clone}/boot/firmware/cmdline.txt
+else
+	cmdline_txt=${clone}/boot/cmdline.txt
+fi
 
 if [ -f $cmdline_txt ]
 then
 	if ((leave_sd_usb_boot && SD_slot_dst))
 	then
 		qecho "Leaving SD to USB boot alone."
-		cp $cmdline_txt ${clone}/boot/cmdline.boot
-		cmdline_txt=${clone}/boot/cmdline.boot
+		# Use the same directory structure as the source for cmdline.boot
+		if [ -f ${clone}/boot/firmware/cmdline.txt ]
+		then
+			cp $cmdline_txt ${clone}/boot/firmware/cmdline.boot
+			cmdline_txt=${clone}/boot/firmware/cmdline.boot
+		else
+			cp $cmdline_txt ${clone}/boot/cmdline.boot
+			cmdline_txt=${clone}/boot/cmdline.boot
+		fi
 	fi
 	if grep -q $src_disk_ID $cmdline_txt
 	then
@@ -1752,8 +1778,15 @@ then
 	if ((leave_sd_usb_boot && SD_slot_boot))
 	then
 		qecho "Copying USB cmdline.txt to SD card to set up USB boot."
-		cp /boot/cmdline.txt /boot/cmdline.boot
-		cp $cmdline_txt /boot/cmdline.txt
+		# Determine the boot directory path
+		if [ -f /boot/firmware/cmdline.txt ]
+		then
+			boot_dir="/boot/firmware"
+		else
+			boot_dir="/boot"
+		fi
+		cp ${boot_dir}/cmdline.txt ${boot_dir}/cmdline.boot
+		cp $cmdline_txt ${boot_dir}/cmdline.txt
 	fi
 fi
 

--- a/rpi-clone
+++ b/rpi-clone
@@ -8,7 +8,7 @@
 #    https://github.com/billw2/rpi-clone
 
 
-version=2.0.22
+version=2.0.23
 
 # setup trusted paths for dependancies (like rsync, grub, fdisk, etc)
 export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"


### PR DESCRIPTION
## Summary
This PR fixes a critical bug where rpi-clone fails to detect and copy boot files on modern Raspberry Pi OS systems that mount the boot partition at `/boot/firmware` instead of the legacy `/boot` location.

## Problem
- Modern Raspberry Pi OS (Bookworm and later) mounts the boot partition at `/boot/firmware`
- rpi-clone v2.0.22 only checks for `/boot`, causing it to miss the boot partition
- This results in cloned SD cards with empty boot partitions that won't boot

## Solution
Added backward-compatible detection for both mount points:
- Checks `/boot/firmware` first (modern systems)
- Falls back to `/boot` if not found (legacy systems)
- Updates all boot partition detection logic throughout the script
- Properly handles `cmdline.txt` in both locations

## Changes Made
1. Updated boot device detection to check both `/boot/firmware` and `/boot`
2. Modified partition mount point checks to recognize both locations
3. Updated `cmdline.txt` path detection for both directory structures
4. Maintained full backward compatibility with older Raspberry Pi OS versions

## Testing
- Tested on Raspberry Pi with modern OS (boot at `/boot/firmware`)
- Successfully clones USB disk to SD card with proper boot files
- Cloned SD card boots correctly

This fix ensures rpi-clone works correctly on both modern and legacy Raspberry Pi OS installations.